### PR TITLE
Page split bug fix

### DIFF
--- a/bitjobs/base/templates/base/commission_list.html
+++ b/bitjobs/base/templates/base/commission_list.html
@@ -50,13 +50,13 @@
                 <div class="pagination">
                   <span class="page-links">
                     {% if page_obj.has_previous %}
-                      <a href="?page={{ page_obj.previous_page_number }}">previous</a>
+                      <a href="?desc={{ request.GET.desc }}&page={{ page_obj.previous_page_number }}">previous</a>
                     {% endif %}
                       <span class="page-current">
                         Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
                       </span>
                       {% if page_obj.has_next %}
-                        <a href="?page={{ page_obj.next_page_number }}">next</a>
+                        <a href="?desc={{ request.GET.desc }}&page={{ page_obj.next_page_number }}">next</a>
                       {% endif %}
                   </span>
                 </div>


### PR DESCRIPTION
Pages of search didn't split correctly. Clicking next would redirect to second page of ALL Commisions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ioteam42/bitjobs/12)
<!-- Reviewable:end -->
